### PR TITLE
Add a way to enumerate all fields

### DIFF
--- a/SwiftCSV.xcodeproj/project.pbxproj
+++ b/SwiftCSV.xcodeproj/project.pbxproj
@@ -16,6 +16,10 @@
 		508975D31DBB897A006F3DBE /* NamedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975D11DBB897A006F3DBE /* NamedView.swift */; };
 		508975D41DBB897A006F3DBE /* NamedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975D11DBB897A006F3DBE /* NamedView.swift */; };
 		508975D51DBB897A006F3DBE /* NamedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975D11DBB897A006F3DBE /* NamedView.swift */; };
+		508975D71DBF34CF006F3DBE /* ParsingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975D61DBF34CF006F3DBE /* ParsingState.swift */; };
+		508975D81DBF34CF006F3DBE /* ParsingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975D61DBF34CF006F3DBE /* ParsingState.swift */; };
+		508975D91DBF34CF006F3DBE /* ParsingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975D61DBF34CF006F3DBE /* ParsingState.swift */; };
+		508975DA1DBF34CF006F3DBE /* ParsingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975D61DBF34CF006F3DBE /* ParsingState.swift */; };
 		5FB74B9B1CCB9274009DDBF1 /* SwiftCSV.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FB74B911CCB9274009DDBF1 /* SwiftCSV.framework */; };
 		5FB74BB71CCB929D009DDBF1 /* SwiftCSV.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FB74BAD1CCB929D009DDBF1 /* SwiftCSV.framework */; };
 		5FB74BD11CCB92E5009DDBF1 /* CSV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAAEE9B1C74C7EC00A933DB /* CSV.swift */; };
@@ -99,6 +103,7 @@
 		3D444BCC1C7D88290001C60C /* String+Lines.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Lines.swift"; sourceTree = "<group>"; };
 		3DAAEE9B1C74C7EC00A933DB /* CSV.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = CSV.swift; sourceTree = "<group>"; tabWidth = 4; };
 		508975D11DBB897A006F3DBE /* NamedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NamedView.swift; sourceTree = "<group>"; };
+		508975D61DBF34CF006F3DBE /* ParsingState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParsingState.swift; sourceTree = "<group>"; };
 		5FB74B911CCB9274009DDBF1 /* SwiftCSV.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftCSV.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FB74B9A1CCB9274009DDBF1 /* SwiftCSVTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftCSVTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FB74BAD1CCB929D009DDBF1 /* SwiftCSV.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftCSV.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -205,6 +210,7 @@
 				BEE5461B1CBBB0F400C0666F /* ParserHelpers.swift */,
 				BEE5461D1CBBB15900C0666F /* Description.swift */,
 				BE9B02D71CBE57B8009FE424 /* Parser.swift */,
+				508975D61DBF34CF006F3DBE /* ParsingState.swift */,
 			);
 			path = SwiftCSV;
 			sourceTree = "<group>";
@@ -530,6 +536,7 @@
 				BEE5461E1CBBB15900C0666F /* Description.swift in Sources */,
 				3DAAEE9C1C74C7EC00A933DB /* CSV.swift in Sources */,
 				BE9B02D81CBE57B8009FE424 /* Parser.swift in Sources */,
+				508975D71DBF34CF006F3DBE /* ParsingState.swift in Sources */,
 				3D444BCD1C7D88290001C60C /* String+Lines.swift in Sources */,
 				BEE5461C1CBBB0F400C0666F /* ParserHelpers.swift in Sources */,
 			);
@@ -555,6 +562,7 @@
 				5FB74BD11CCB92E5009DDBF1 /* CSV.swift in Sources */,
 				5FB74BD21CCB92E5009DDBF1 /* String+Lines.swift in Sources */,
 				5FB74BD31CCB92E5009DDBF1 /* ParserHelpers.swift in Sources */,
+				508975D81DBF34CF006F3DBE /* ParsingState.swift in Sources */,
 				5FB74BD41CCB92E5009DDBF1 /* Description.swift in Sources */,
 				5FB74BD51CCB92E5009DDBF1 /* Parser.swift in Sources */,
 			);
@@ -580,6 +588,7 @@
 				5FB74BD61CCB92EB009DDBF1 /* CSV.swift in Sources */,
 				5FB74BD71CCB92EB009DDBF1 /* String+Lines.swift in Sources */,
 				5FB74BD81CCB92EB009DDBF1 /* ParserHelpers.swift in Sources */,
+				508975D91DBF34CF006F3DBE /* ParsingState.swift in Sources */,
 				5FB74BD91CCB92EB009DDBF1 /* Description.swift in Sources */,
 				5FB74BDA1CCB92EB009DDBF1 /* Parser.swift in Sources */,
 			);
@@ -605,6 +614,7 @@
 				5FB74BDB1CCB92F1009DDBF1 /* CSV.swift in Sources */,
 				5FB74BDC1CCB92F1009DDBF1 /* String+Lines.swift in Sources */,
 				5FB74BDD1CCB92F1009DDBF1 /* ParserHelpers.swift in Sources */,
+				508975DA1DBF34CF006F3DBE /* ParsingState.swift in Sources */,
 				5FB74BDE1CCB92F1009DDBF1 /* Description.swift in Sources */,
 				5FB74BDF1CCB92F1009DDBF1 /* Parser.swift in Sources */,
 			);

--- a/SwiftCSV.xcodeproj/project.pbxproj
+++ b/SwiftCSV.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		3D3749E3194D6DF7008F262A /* TSVTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D3749E2194D6DF7008F262A /* TSVTests.swift */; };
 		3D444BCD1C7D88290001C60C /* String+Lines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D444BCC1C7D88290001C60C /* String+Lines.swift */; };
 		3DAAEE9C1C74C7EC00A933DB /* CSV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAAEE9B1C74C7EC00A933DB /* CSV.swift */; };
+		508975D21DBB897A006F3DBE /* NamedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975D11DBB897A006F3DBE /* NamedView.swift */; };
+		508975D31DBB897A006F3DBE /* NamedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975D11DBB897A006F3DBE /* NamedView.swift */; };
+		508975D41DBB897A006F3DBE /* NamedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975D11DBB897A006F3DBE /* NamedView.swift */; };
+		508975D51DBB897A006F3DBE /* NamedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975D11DBB897A006F3DBE /* NamedView.swift */; };
 		5FB74B9B1CCB9274009DDBF1 /* SwiftCSV.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FB74B911CCB9274009DDBF1 /* SwiftCSV.framework */; };
 		5FB74BB71CCB929D009DDBF1 /* SwiftCSV.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FB74BAD1CCB929D009DDBF1 /* SwiftCSV.framework */; };
 		5FB74BD11CCB92E5009DDBF1 /* CSV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAAEE9B1C74C7EC00A933DB /* CSV.swift */; };
@@ -94,6 +98,7 @@
 		3D3749E2194D6DF7008F262A /* TSVTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TSVTests.swift; sourceTree = "<group>"; };
 		3D444BCC1C7D88290001C60C /* String+Lines.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Lines.swift"; sourceTree = "<group>"; };
 		3DAAEE9B1C74C7EC00A933DB /* CSV.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = CSV.swift; sourceTree = "<group>"; tabWidth = 4; };
+		508975D11DBB897A006F3DBE /* NamedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NamedView.swift; sourceTree = "<group>"; };
 		5FB74B911CCB9274009DDBF1 /* SwiftCSV.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftCSV.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FB74B9A1CCB9274009DDBF1 /* SwiftCSVTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftCSVTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FB74BAD1CCB929D009DDBF1 /* SwiftCSV.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftCSV.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -195,6 +200,7 @@
 			isa = PBXGroup;
 			children = (
 				3DAAEE9B1C74C7EC00A933DB /* CSV.swift */,
+				508975D11DBB897A006F3DBE /* NamedView.swift */,
 				3D444BCC1C7D88290001C60C /* String+Lines.swift */,
 				BEE5461B1CBBB0F400C0666F /* ParserHelpers.swift */,
 				BEE5461D1CBBB15900C0666F /* Description.swift */,
@@ -520,6 +526,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				508975D21DBB897A006F3DBE /* NamedView.swift in Sources */,
 				BEE5461E1CBBB15900C0666F /* Description.swift in Sources */,
 				3DAAEE9C1C74C7EC00A933DB /* CSV.swift in Sources */,
 				BE9B02D81CBE57B8009FE424 /* Parser.swift in Sources */,
@@ -544,6 +551,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				508975D31DBB897A006F3DBE /* NamedView.swift in Sources */,
 				5FB74BD11CCB92E5009DDBF1 /* CSV.swift in Sources */,
 				5FB74BD21CCB92E5009DDBF1 /* String+Lines.swift in Sources */,
 				5FB74BD31CCB92E5009DDBF1 /* ParserHelpers.swift in Sources */,
@@ -568,6 +576,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				508975D41DBB897A006F3DBE /* NamedView.swift in Sources */,
 				5FB74BD61CCB92EB009DDBF1 /* CSV.swift in Sources */,
 				5FB74BD71CCB92EB009DDBF1 /* String+Lines.swift in Sources */,
 				5FB74BD81CCB92EB009DDBF1 /* ParserHelpers.swift in Sources */,
@@ -592,6 +601,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				508975D51DBB897A006F3DBE /* NamedView.swift in Sources */,
 				5FB74BDB1CCB92F1009DDBF1 /* CSV.swift in Sources */,
 				5FB74BDC1CCB92F1009DDBF1 /* String+Lines.swift in Sources */,
 				5FB74BDD1CCB92F1009DDBF1 /* ParserHelpers.swift in Sources */,

--- a/SwiftCSV.xcodeproj/project.pbxproj
+++ b/SwiftCSV.xcodeproj/project.pbxproj
@@ -20,6 +20,13 @@
 		508975D81DBF34CF006F3DBE /* ParsingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975D61DBF34CF006F3DBE /* ParsingState.swift */; };
 		508975D91DBF34CF006F3DBE /* ParsingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975D61DBF34CF006F3DBE /* ParsingState.swift */; };
 		508975DA1DBF34CF006F3DBE /* ParsingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975D61DBF34CF006F3DBE /* ParsingState.swift */; };
+		508975DC1DBF3B70006F3DBE /* EnumeratedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975DB1DBF3B70006F3DBE /* EnumeratedView.swift */; };
+		508975DD1DBF3B70006F3DBE /* EnumeratedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975DB1DBF3B70006F3DBE /* EnumeratedView.swift */; };
+		508975DE1DBF3B70006F3DBE /* EnumeratedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975DB1DBF3B70006F3DBE /* EnumeratedView.swift */; };
+		508975DF1DBF3B70006F3DBE /* EnumeratedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975DB1DBF3B70006F3DBE /* EnumeratedView.swift */; };
+		508975E11DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975E01DBF3E51006F3DBE /* EnumeratedViewTests.swift */; };
+		508975E21DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975E01DBF3E51006F3DBE /* EnumeratedViewTests.swift */; };
+		508975E31DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508975E01DBF3E51006F3DBE /* EnumeratedViewTests.swift */; };
 		5FB74B9B1CCB9274009DDBF1 /* SwiftCSV.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FB74B911CCB9274009DDBF1 /* SwiftCSV.framework */; };
 		5FB74BB71CCB929D009DDBF1 /* SwiftCSV.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FB74BAD1CCB929D009DDBF1 /* SwiftCSV.framework */; };
 		5FB74BD11CCB92E5009DDBF1 /* CSV.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAAEE9B1C74C7EC00A933DB /* CSV.swift */; };
@@ -104,6 +111,8 @@
 		3DAAEE9B1C74C7EC00A933DB /* CSV.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = CSV.swift; sourceTree = "<group>"; tabWidth = 4; };
 		508975D11DBB897A006F3DBE /* NamedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NamedView.swift; sourceTree = "<group>"; };
 		508975D61DBF34CF006F3DBE /* ParsingState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParsingState.swift; sourceTree = "<group>"; };
+		508975DB1DBF3B70006F3DBE /* EnumeratedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumeratedView.swift; sourceTree = "<group>"; };
+		508975E01DBF3E51006F3DBE /* EnumeratedViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumeratedViewTests.swift; sourceTree = "<group>"; };
 		5FB74B911CCB9274009DDBF1 /* SwiftCSV.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftCSV.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FB74B9A1CCB9274009DDBF1 /* SwiftCSVTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftCSVTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FB74BAD1CCB929D009DDBF1 /* SwiftCSV.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftCSV.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -206,6 +215,7 @@
 			children = (
 				3DAAEE9B1C74C7EC00A933DB /* CSV.swift */,
 				508975D11DBB897A006F3DBE /* NamedView.swift */,
+				508975DB1DBF3B70006F3DBE /* EnumeratedView.swift */,
 				3D444BCC1C7D88290001C60C /* String+Lines.swift */,
 				BEE5461B1CBBB0F400C0666F /* ParserHelpers.swift */,
 				BEE5461D1CBBB15900C0666F /* Description.swift */,
@@ -220,6 +230,7 @@
 			children = (
 				BE06B67E1CB72680009578CC /* Res */,
 				3D1E59C61945FFAD001CF760 /* CSVTests.swift */,
+				508975E01DBF3E51006F3DBE /* EnumeratedViewTests.swift */,
 				BE6C86061CB5CE44009A351D /* QuotedTests.swift */,
 				3D3749E2194D6DF7008F262A /* TSVTests.swift */,
 				BE06B67F1CB726B5009578CC /* URLTests.swift */,
@@ -536,6 +547,7 @@
 				BEE5461E1CBBB15900C0666F /* Description.swift in Sources */,
 				3DAAEE9C1C74C7EC00A933DB /* CSV.swift in Sources */,
 				BE9B02D81CBE57B8009FE424 /* Parser.swift in Sources */,
+				508975DC1DBF3B70006F3DBE /* EnumeratedView.swift in Sources */,
 				508975D71DBF34CF006F3DBE /* ParsingState.swift in Sources */,
 				3D444BCD1C7D88290001C60C /* String+Lines.swift in Sources */,
 				BEE5461C1CBBB0F400C0666F /* ParserHelpers.swift in Sources */,
@@ -548,6 +560,7 @@
 			files = (
 				E46085941CCB1F5C00385286 /* PerformanceTest.swift in Sources */,
 				3D1E59C71945FFAD001CF760 /* CSVTests.swift in Sources */,
+				508975E11DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */,
 				3D3749E3194D6DF7008F262A /* TSVTests.swift in Sources */,
 				BE06B6801CB726B5009578CC /* URLTests.swift in Sources */,
 				BE6C86071CB5CE44009A351D /* QuotedTests.swift in Sources */,
@@ -562,6 +575,7 @@
 				5FB74BD11CCB92E5009DDBF1 /* CSV.swift in Sources */,
 				5FB74BD21CCB92E5009DDBF1 /* String+Lines.swift in Sources */,
 				5FB74BD31CCB92E5009DDBF1 /* ParserHelpers.swift in Sources */,
+				508975DD1DBF3B70006F3DBE /* EnumeratedView.swift in Sources */,
 				508975D81DBF34CF006F3DBE /* ParsingState.swift in Sources */,
 				5FB74BD41CCB92E5009DDBF1 /* Description.swift in Sources */,
 				5FB74BD51CCB92E5009DDBF1 /* Parser.swift in Sources */,
@@ -574,6 +588,7 @@
 			files = (
 				5FB74BE01CCB9312009DDBF1 /* CSVTests.swift in Sources */,
 				5FB74BE11CCB9312009DDBF1 /* QuotedTests.swift in Sources */,
+				508975E21DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */,
 				5FB74BE21CCB9312009DDBF1 /* TSVTests.swift in Sources */,
 				5FB74BE31CCB9312009DDBF1 /* URLTests.swift in Sources */,
 				5FB74BE41CCB9312009DDBF1 /* PerformanceTest.swift in Sources */,
@@ -588,6 +603,7 @@
 				5FB74BD61CCB92EB009DDBF1 /* CSV.swift in Sources */,
 				5FB74BD71CCB92EB009DDBF1 /* String+Lines.swift in Sources */,
 				5FB74BD81CCB92EB009DDBF1 /* ParserHelpers.swift in Sources */,
+				508975DE1DBF3B70006F3DBE /* EnumeratedView.swift in Sources */,
 				508975D91DBF34CF006F3DBE /* ParsingState.swift in Sources */,
 				5FB74BD91CCB92EB009DDBF1 /* Description.swift in Sources */,
 				5FB74BDA1CCB92EB009DDBF1 /* Parser.swift in Sources */,
@@ -600,6 +616,7 @@
 			files = (
 				5FB74BE51CCB931F009DDBF1 /* CSVTests.swift in Sources */,
 				5FB74BE61CCB931F009DDBF1 /* QuotedTests.swift in Sources */,
+				508975E31DBF3E51006F3DBE /* EnumeratedViewTests.swift in Sources */,
 				5FB74BE71CCB931F009DDBF1 /* TSVTests.swift in Sources */,
 				5FB74BE81CCB931F009DDBF1 /* URLTests.swift in Sources */,
 				5FB74BE91CCB931F009DDBF1 /* PerformanceTest.swift in Sources */,
@@ -614,6 +631,7 @@
 				5FB74BDB1CCB92F1009DDBF1 /* CSV.swift in Sources */,
 				5FB74BDC1CCB92F1009DDBF1 /* String+Lines.swift in Sources */,
 				5FB74BDD1CCB92F1009DDBF1 /* ParserHelpers.swift in Sources */,
+				508975DF1DBF3B70006F3DBE /* EnumeratedView.swift in Sources */,
 				508975DA1DBF34CF006F3DBE /* ParsingState.swift in Sources */,
 				5FB74BDE1CCB92F1009DDBF1 /* Description.swift in Sources */,
 				5FB74BDF1CCB92F1009DDBF1 /* Parser.swift in Sources */,

--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -37,8 +37,13 @@ open class CSV {
     let loadColumns: Bool
 
     /// List of dictionaries that contains the CSV data
-    public var rows: [[String : String]] {
+    public var namedRows: [[String : String]] {
         return _namedView.rows
+    }
+
+    @available(*, unavailable, renamed: "namedRows")
+    public var rows: [[String : String]] {
+        return namedRows
     }
 
     /// Dictionary of header name to list of values in that column

--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -12,8 +12,24 @@ open class CSV {
     static fileprivate let comma: Character = ","
     
     open var header: [String]!
-    var _rows: [[String: String]]? = nil
-    var _namedColumns: [String: [String]]? = nil
+
+    lazy var _namedView: NamedView = {
+
+        var rows = [[String: String]]()
+        var columns = [String: [String]]()
+
+        self.enumerateAsDict { dict in
+            rows.append(dict)
+        }
+
+        if self.loadColumns {
+            for field in self.header {
+                columns[field] = rows.map { $0[field] ?? "" }
+            }
+        }
+
+        return NamedView(rows: rows, columns: columns)
+    }()
     
     var text: String
     var delimiter: Character
@@ -22,26 +38,20 @@ open class CSV {
 
     /// List of dictionaries that contains the CSV data
     public var rows: [[String : String]] {
-        if _rows == nil {
-            parse()
-        }
-        return _rows!
+        return _namedView.rows
     }
 
     /// Dictionary of header name to list of values in that column
     /// Will not be loaded if loadColumns in init is false
     public var namedColumns: [String : [String]] {
-        if !loadColumns {
-            return [:]
-        } else if _namedColumns == nil {
-            parse()
-        }
-        return _namedColumns!
+        return _namedView.columns
     }
 
     @available(*, unavailable, renamed: "namedColumns")
-    public var columns: [String : [String]] { return namedColumns }
-    
+    public var columns: [String : [String]] {
+        return namedColumns
+    }
+
     
     /// Load a CSV file from a string
     ///

--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -30,6 +30,24 @@ open class CSV {
 
         return NamedView(rows: rows, columns: columns)
     }()
+
+    lazy var _enumeratedView: EnumeratedView = {
+
+        var rows = [[String]]()
+        var columns: [EnumeratedView.Column] = []
+        self.enumerateAsArray { rows.append($0) }
+
+        if self.loadColumns {
+            columns = self.header.enumerated().map { (index: Int, header: String) -> EnumeratedView.Column in
+
+                return EnumeratedView.Column(
+                    header: header,
+                    rows: rows.map { $0[index] })
+            }
+        }
+
+        return EnumeratedView(rows: rows, columns: columns)
+    }()
     
     var text: String
     var delimiter: Character
@@ -41,15 +59,29 @@ open class CSV {
         return _namedView.rows
     }
 
-    @available(*, unavailable, renamed: "namedRows")
-    public var rows: [[String : String]] {
-        return namedRows
-    }
-
     /// Dictionary of header name to list of values in that column
     /// Will not be loaded if loadColumns in init is false
     public var namedColumns: [String : [String]] {
         return _namedView.columns
+    }
+
+    /// Collection of column fields that contain the CSV data
+    public var enumeratedRows: [[String]] {
+        return _enumeratedView.rows
+    }
+
+    /// Collection of columns with metadata.
+    /// Will not be loaded if loadColumns in init is false
+    public var enumeratedColumns: [EnumeratedView.Column] {
+        return _enumeratedView.columns
+    }
+    
+
+
+
+    @available(*, unavailable, renamed: "namedRows")
+    public var rows: [[String : String]] {
+        return namedRows
     }
 
     @available(*, unavailable, renamed: "namedColumns")

--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -55,9 +55,9 @@ open class CSV {
     
     /// Load a CSV file from a string
     ///
-    /// string: string data of the CSV file
-    /// delimiter: character to split row and header fields by (default is ',')
-    /// loadColumns: whether to populate the columns dictionary (default is true)
+    /// - parameter string: Contents of the CSV file
+    /// - parameter delimiter: Character to split row and header fields by (default is ',')
+    /// - parameter loadColumns: Whether to populate the columns dictionary (default is true)
     public init(string: String, delimiter: Character = comma, loadColumns: Bool = true) {
         self.text = string
         self.delimiter = delimiter
@@ -67,11 +67,11 @@ open class CSV {
     
     /// Load a CSV file
     ///
-    /// name: name of the file (will be passed to String(contentsOfFile:encoding:) to load)
-    /// delimiter: character to split row and header fields by (default is ',')
-    /// encoding: encoding used to read file (default is NSUTF8StringEncoding)
-    /// loadColumns: whether to populate the columns dictionary (default is true)
-    public convenience init(name: String, delimiter: Character = comma, encoding: String.Encoding = String.Encoding.utf8, loadColumns: Bool = true) throws {
+    /// - parameter name: name of the file (will be passed to String(contentsOfFile:encoding:) to load)
+    /// - parameter delimiter: character to split row and header fields by (default is ',')
+    /// - parameter encoding: encoding used to read file (default is UTF-8)
+    /// - parameter loadColumns: whether to populate the columns dictionary (default is true)
+    public convenience init(name: String, delimiter: Character = comma, encoding: String.Encoding = .utf8, loadColumns: Bool = true) throws {
         let contents = try String(contentsOfFile: name, encoding: encoding)
     
         self.init(string: contents, delimiter: delimiter, loadColumns: loadColumns)
@@ -79,11 +79,11 @@ open class CSV {
     
     /// Load a CSV file from a URL
     ///
-    /// url: url pointing to the file (will be passed to String(contentsOfURL:encoding:) to load)
-    /// delimiter: character to split row and header fields by (default is ',')
-    /// encoding: encoding used to read file (default is NSUTF8StringEncoding)
-    /// loadColumns: whether to populate the columns dictionary (default is true)
-    public convenience init(url: URL, delimiter: Character = comma, encoding: String.Encoding = String.Encoding.utf8, loadColumns: Bool = true) throws {
+    /// - parameter url: url pointing to the file (will be passed to String(contentsOfURL:encoding:) to load)
+    /// - parameter delimiter: character to split row and header fields by (default is ',')
+    /// - parameter encoding: encoding used to read file (default is UTF-8)
+    /// - parameter loadColumns: whether to populate the columns dictionary (default is true)
+    public convenience init(url: URL, delimiter: Character = comma, encoding: String.Encoding = .utf8, loadColumns: Bool = true) throws {
         let contents = try String(contentsOf: url, encoding: encoding)
         
         self.init(string: contents, delimiter: delimiter, loadColumns: loadColumns)

--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -13,7 +13,7 @@ open class CSV {
     
     open var header: [String]!
     var _rows: [[String: String]]? = nil
-    var _columns: [String: [String]]? = nil
+    var _namedColumns: [String: [String]]? = nil
     
     var text: String
     var delimiter: Character

--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -11,7 +11,7 @@ import Foundation
 open class CSV {
     static fileprivate let comma: Character = ","
     
-    open var header: [String]!
+    open let header: [String]
 
     lazy var _namedView: NamedView = {
 
@@ -62,11 +62,7 @@ open class CSV {
         self.text = string
         self.delimiter = delimiter
         self.loadColumns = loadColumns
-        
-        let createHeader: ([String]) -> () = { head in
-            self.header = head
-        }
-        enumerateAsArray(createHeader, limitTo: 1, startAt: 0)
+        self.header = CSV.array(text: string, delimiter: delimiter).first ?? []
     }
     
     /// Load a CSV file

--- a/SwiftCSV/CSV.swift
+++ b/SwiftCSV/CSV.swift
@@ -19,6 +19,29 @@ open class CSV {
     var delimiter: Character
     
     let loadColumns: Bool
+
+    /// List of dictionaries that contains the CSV data
+    public var rows: [[String : String]] {
+        if _rows == nil {
+            parse()
+        }
+        return _rows!
+    }
+
+    /// Dictionary of header name to list of values in that column
+    /// Will not be loaded if loadColumns in init is false
+    public var namedColumns: [String : [String]] {
+        if !loadColumns {
+            return [:]
+        } else if _namedColumns == nil {
+            parse()
+        }
+        return _namedColumns!
+    }
+
+    @available(*, unavailable, renamed: "namedColumns")
+    public var columns: [String : [String]] { return namedColumns }
+    
     
     /// Load a CSV file from a string
     ///

--- a/SwiftCSV/Description.swift
+++ b/SwiftCSV/Description.swift
@@ -12,7 +12,7 @@ extension CSV: CustomStringConvertible {
     public var description: String {
         let head = header.joined(separator: ",") + "\n"
         
-        let cont = rows.map { row in
+        let cont = namedRows.map { row in
             header.map { row[$0]! }.joined(separator: ",")
         }.joined(separator: "\n")
         return head + cont

--- a/SwiftCSV/EnumeratedView.swift
+++ b/SwiftCSV/EnumeratedView.swift
@@ -1,0 +1,20 @@
+//
+//  EnumeratedView.swift
+//  SwiftCSV
+//
+//  Created by Christian Tietze on 25/10/16.
+//  Copyright © 2016 Naoto Kaneko. All rights reserved.
+//
+
+import Foundation
+
+public struct EnumeratedView {
+
+    public struct Column {
+        public let header: String
+        public let rows: [String]
+    }
+
+    var rows: [[String]]
+    var columns: [Column]
+}

--- a/SwiftCSV/NamedView.swift
+++ b/SwiftCSV/NamedView.swift
@@ -1,0 +1,15 @@
+//
+//  NamedView.swift
+//  SwiftCSV
+//
+//  Created by Christian Tietze on 22/10/16.
+//  Copyright © 2016 Naoto Kaneko. All rights reserved.
+//
+
+import Foundation
+
+struct NamedView {
+
+    var rows: [[String: String]]
+    var columns: [String: [String]]
+}

--- a/SwiftCSV/NamedView.swift
+++ b/SwiftCSV/NamedView.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2016 Naoto Kaneko. All rights reserved.
 //
 
-import Foundation
-
 struct NamedView {
 
     var rows: [[String: String]]

--- a/SwiftCSV/Parser.swift
+++ b/SwiftCSV/Parser.swift
@@ -6,12 +6,6 @@
 //  Copyright © 2016 Naoto Kaneko. All rights reserved.
 //
 
-fileprivate extension Character {
-    var isNewline: Bool {
-        return self == "\n" || self == "\r\n"
-    }
-}
-
 extension CSV {
     /// Parse the file and call a block on each row, passing it in as a list of fields
     /// limitTo will limit the result to a certain number of lines
@@ -43,11 +37,6 @@ extension CSV {
         var currentIndex = text.startIndex
         let endIndex = text.endIndex
 
-        var atStart = true
-        var parsingField = false
-        var parsingQuotes = false
-        var innerQuotes = false
-
         var fields = [String]()
         var field = ""
 
@@ -63,77 +52,14 @@ extension CSV {
             field = ""
         }
 
-        func changeState(_ char: Character) {
-            if atStart {
-                if char == "\"" {
-                    atStart = false
-                    parsingQuotes = true
-                } else if char == delimiter {
-                    fields.append(field)
-                    field = ""
-                } else if char.isNewline {
-                    finishRow()
-                } else {
-                    parsingField = true
-                    atStart = false
-                    field.append(char)
-                }
-            } else if parsingField {
-                if innerQuotes {
-                    if char == "\"" {
-                        field.append(char)
-                        innerQuotes = false
-                    } else {
-                        fatalError("Can't have non-quote here: \(char)")
-                    }
-                } else {
-                    if char == "\"" {
-                        innerQuotes = true
-                    } else if char == delimiter {
-                        atStart = true
-                        parsingField = false
-                        innerQuotes = false
-                        fields.append(field)
-                        field = ""
-                    } else if char.isNewline {
-                        atStart = true
-                        parsingField = false
-                        innerQuotes = false
-                        finishRow()
-                    } else {
-                        field.append(char)
-                    }
-                }
-            } else if parsingQuotes {
-                if innerQuotes {
-                    if char == "\"" {
-                        field.append(char)
-                        innerQuotes = false
-                    } else if char == delimiter {
-                        atStart = true
-                        parsingField = false
-                        innerQuotes = false
-                        fields.append(field)
-                        field = ""
-                    } else if char.isNewline {
-                        atStart = true
-                        parsingQuotes = false
-                        innerQuotes = false
-                        finishRow()
-                    } else {
-                        fatalError("Can't have non-quote here: \(char)")
-                    }
-                } else {
-                    if char == "\"" {
-                        innerQuotes = true
-                    } else {
-                        field.append(char)
-                    }
-                }
-            } else {
-                fatalError("me_irl")
-            }
-        }
+        var state: ParsingState = ParsingState(
+            delimiter: delimiter,
+            finishRow: finishRow,
+            appendChar: { field.append($0) },
+            finishField: {
+                fields.append(field)
+                field = ""
+        })
 
         func limitReached(_ count: Int) -> Bool {
 
@@ -147,7 +73,7 @@ extension CSV {
         while currentIndex < endIndex {
             let char = text[currentIndex]
 
-            changeState(char)
+            state.change(char)
 
             if limitReached(count) {
                 break

--- a/SwiftCSV/Parser.swift
+++ b/SwiftCSV/Parser.swift
@@ -13,10 +13,21 @@ extension CSV {
 
         CSV.enumerateAsArray(text: self.text, delimiter: self.delimiter, limitTo: limitTo, startAt: startAt, block: block)
     }
+
+    static func array(text: String, delimiter: Character, limitTo: Int? = nil, startAt: Int = 0) -> [[String]] {
+
+        var rows = [[String]]()
+
+        enumerateAsArray(text: text, delimiter: delimiter) { row in
+            rows.append(row)
+        }
+
+        return rows
+    }
+
     static func enumerateAsArray(text: String, delimiter: Character, limitTo: Int? = nil, startAt: Int = 0, block: @escaping ([String]) -> ()) {
         var currentIndex = text.startIndex
         let endIndex = text.endIndex
-        
 
         var atStart = true
         var parsingField = false
@@ -125,7 +136,6 @@ extension CSV {
             block(fields)
         }
     }
-    
 
     fileprivate static func isNewline(_ char: Character) -> Bool {
         return char == "\n" || char == "\r\n"

--- a/SwiftCSV/Parser.swift
+++ b/SwiftCSV/Parser.swift
@@ -43,19 +43,19 @@ extension CSV {
         var innerQuotes = false
 
         var fields = [String]()
-        var field = [Character]()
+        var field = ""
 
         var count = 0
         let doLimit = limitTo != nil
 
-        let callBlock: () -> () = {
+        let finishRow: () -> () = {
             fields.append(String(field))
             if count >= startAt {
                 block(fields)
             }
             count += 1
             fields = [String]()
-            field = [Character]()
+            field = ""
         }
 
         let changeState: (Character) -> (Bool) = { char in
@@ -64,10 +64,10 @@ extension CSV {
                     atStart = false
                     parsingQuotes = true
                 } else if char == delimiter {
-                    fields.append(String(field))
-                    field = [Character]()
+                    fields.append(field)
+                    field = ""
                 } else if CSV.isNewline(char) {
-                    callBlock()
+                    finishRow()
                 } else {
                     parsingField = true
                     atStart = false
@@ -88,13 +88,13 @@ extension CSV {
                         atStart = true
                         parsingField = false
                         innerQuotes = false
-                        fields.append(String(field))
-                        field = [Character]()
+                        fields.append(field)
+                        field = ""
                     } else if CSV.isNewline(char) {
                         atStart = true
                         parsingField = false
                         innerQuotes = false
-                        callBlock()
+                        finishRow()
                     } else {
                         field.append(char)
                     }
@@ -108,13 +108,13 @@ extension CSV {
                         atStart = true
                         parsingField = false
                         innerQuotes = false
-                        fields.append(String(field))
-                        field = [Character]()
+                        fields.append(field)
+                        field = ""
                     } else if CSV.isNewline(char) {
                         atStart = true
                         parsingQuotes = false
                         innerQuotes = false
-                        callBlock()
+                        finishRow()
                     } else {
                         fatalError("Can't have non-quote here: \(char)")
                     }
@@ -139,8 +139,8 @@ extension CSV {
             currentIndex = text.index(after: currentIndex)
         }
 
-        if fields.count != 0 || field.count != 0 || (doLimit && count < limitTo!) {
-            fields.append(String(field))
+        if !fields.isEmpty || !field.isEmpty || (doLimit && count < limitTo!) {
+            fields.append(field)
             block(fields)
         }
     }

--- a/SwiftCSV/Parser.swift
+++ b/SwiftCSV/Parser.swift
@@ -10,20 +10,25 @@ extension CSV {
     /// Parse the file and call a block on each row, passing it in as a list of fields
     /// limitTo will limit the result to a certain number of lines
     func enumerateAsArray(_ block: @escaping ([String]) -> (), limitTo: Int?, startAt: Int = 0) {
+
+        CSV.enumerateAsArray(text: self.text, delimiter: self.delimiter, limitTo: limitTo, startAt: startAt, block: block)
+    }
+    static func enumerateAsArray(text: String, delimiter: Character, limitTo: Int? = nil, startAt: Int = 0, block: @escaping ([String]) -> ()) {
         var currentIndex = text.startIndex
         let endIndex = text.endIndex
         
+
         var atStart = true
         var parsingField = false
         var parsingQuotes = false
         var innerQuotes = false
-        
+
         var fields = [String]()
         var field = [Character]()
-        
+
         var count = 0
         let doLimit = limitTo != nil
-        
+
         let callBlock: () -> () = {
             fields.append(String(field))
             if count >= startAt {
@@ -33,13 +38,13 @@ extension CSV {
             fields = [String]()
             field = [Character]()
         }
-        
+
         let changeState: (Character) -> (Bool) = { char in
             if atStart {
                 if char == "\"" {
                     atStart = false
                     parsingQuotes = true
-                } else if char == self.delimiter {
+                } else if char == delimiter {
                     fields.append(String(field))
                     field = [Character]()
                 } else if CSV.isNewline(char) {
@@ -60,7 +65,7 @@ extension CSV {
                 } else {
                     if char == "\"" {
                         innerQuotes = true
-                    } else if char == self.delimiter {
+                    } else if char == delimiter {
                         atStart = true
                         parsingField = false
                         innerQuotes = false
@@ -80,7 +85,7 @@ extension CSV {
                     if char == "\"" {
                         field.append(char)
                         innerQuotes = false
-                    } else if char == self.delimiter {
+                    } else if char == delimiter {
                         atStart = true
                         parsingField = false
                         innerQuotes = false
@@ -106,7 +111,7 @@ extension CSV {
             }
             return doLimit && count >= limitTo!
         }
-        
+
         while currentIndex < endIndex {
             let char = text[currentIndex]
             if changeState(char) {
@@ -114,13 +119,14 @@ extension CSV {
             }
             currentIndex = text.index(after: currentIndex)
         }
-        
+
         if fields.count != 0 || field.count != 0 || (doLimit && count < limitTo!) {
             fields.append(String(field))
             block(fields)
         }
     }
     
+
     fileprivate static func isNewline(_ char: Character) -> Bool {
         return char == "\n" || char == "\r\n"
     }

--- a/SwiftCSV/Parser.swift
+++ b/SwiftCSV/Parser.swift
@@ -25,6 +25,14 @@ extension CSV {
         return rows
     }
 
+    /// Parse the text and call a block on each row, passing it in as a list of fields.
+    ///
+    /// - parameter text: Text to parse.
+    /// - parameter delimiter: Character to split row and header fields by (default is ',')
+    /// - parameter limitTo: If set to non-nil value, enumeration stops 
+    ///   at the row with index `limitTo` (or on end-of-text, whichever is earlier.
+    /// - parameter startAt: Offset of rows to ignore before invoking `block` for the first time. Default is 0.
+    /// - parameter block: Callback invoked for every parsed row between `startAt` and `limitTo` in `text`.
     static func enumerateAsArray(text: String, delimiter: Character, limitTo: Int? = nil, startAt: Int = 0, block: @escaping ([String]) -> ()) {
         var currentIndex = text.startIndex
         let endIndex = text.endIndex

--- a/SwiftCSV/ParserHelpers.swift
+++ b/SwiftCSV/ParserHelpers.swift
@@ -7,7 +7,7 @@
 //
 
 extension CSV {
-    
+
     /// Parse the file and call a block for each row, passing it as a dictionary
     public func enumerateAsDict(_ block: @escaping ([String : String]) -> ()) {
         let enumeratedHeader = header.enumerated()
@@ -26,21 +26,4 @@ extension CSV {
         self.enumerateAsArray(block, limitTo: nil, startAt: 1)
     }
     
-    fileprivate func parse() {
-        var rows = [[String: String]]()
-        var columns = [String: [String]]()
-        
-        enumerateAsDict { dict in
-            rows.append(dict)
-        }
-
-        if loadColumns {
-            for field in header {
-                columns[field] = rows.map { $0[field] ?? "" }
-            }
-        }
-        
-        _namedColumns = columns
-        _rows = rows
-    }
 }

--- a/SwiftCSV/ParserHelpers.swift
+++ b/SwiftCSV/ParserHelpers.swift
@@ -8,7 +8,7 @@
 
 extension CSV {
     /// List of dictionaries that contains the CSV data
-    public var rows: [[String: String]] {
+    public var rows: [[String : String]] {
         if _rows == nil {
             parse()
         }
@@ -17,19 +17,22 @@ extension CSV {
     
     /// Dictionary of header name to list of values in that column
     /// Will not be loaded if loadColumns in init is false
-    public var columns: [String: [String]] {
+    public var namedColumns: [String : [String]] {
         if !loadColumns {
             return [:]
-        } else if _columns == nil {
+        } else if _namedColumns == nil {
             parse()
         }
-        return _columns!
+        return _namedColumns!
     }
+
+    @available(*, unavailable, renamed: "namedColumns")
+    public var columns: [String : [String]] { return namedColumns }
     
     /// Parse the file and call a block for each row, passing it as a dictionary
-    public func enumerateAsDict(_ block: @escaping ([String: String]) -> ()) {
+    public func enumerateAsDict(_ block: @escaping ([String : String]) -> ()) {
         let enumeratedHeader = header.enumerated()
-        
+
         enumerateAsArray { fields in
             var dict = [String: String]()
             for (index, head) in enumeratedHeader {
@@ -58,7 +61,7 @@ extension CSV {
             }
         }
         
-        _columns = columns
+        _namedColumns = columns
         _rows = rows
     }
 }

--- a/SwiftCSV/ParserHelpers.swift
+++ b/SwiftCSV/ParserHelpers.swift
@@ -7,27 +7,6 @@
 //
 
 extension CSV {
-    /// List of dictionaries that contains the CSV data
-    public var rows: [[String : String]] {
-        if _rows == nil {
-            parse()
-        }
-        return _rows!
-    }
-    
-    /// Dictionary of header name to list of values in that column
-    /// Will not be loaded if loadColumns in init is false
-    public var namedColumns: [String : [String]] {
-        if !loadColumns {
-            return [:]
-        } else if _namedColumns == nil {
-            parse()
-        }
-        return _namedColumns!
-    }
-
-    @available(*, unavailable, renamed: "namedColumns")
-    public var columns: [String : [String]] { return namedColumns }
     
     /// Parse the file and call a block for each row, passing it as a dictionary
     public func enumerateAsDict(_ block: @escaping ([String : String]) -> ()) {

--- a/SwiftCSV/ParsingState.swift
+++ b/SwiftCSV/ParsingState.swift
@@ -1,0 +1,107 @@
+//
+//  ParsingState.swift
+//  SwiftCSV
+//
+//  Created by Christian Tietze on 25/10/16.
+//  Copyright © 2016 Naoto Kaneko. All rights reserved.
+//
+
+fileprivate extension Character {
+    var isNewline: Bool {
+        return self == "\n" || self == "\r\n"
+    }
+}
+
+/// State machine of parsing CSV contents character by character.
+struct ParsingState {
+
+    private(set) var atStart = true
+    private(set) var parsingField = false
+    private(set) var parsingQuotes = false
+    private(set) var innerQuotes = false
+
+    let delimiter: Character
+    let finishRow: () -> Void
+    let appendChar: (Character) -> Void
+    let finishField: () -> Void
+
+    init(delimiter: Character,
+         finishRow: @escaping () -> Void,
+         appendChar: @escaping (Character) -> Void,
+         finishField: @escaping () -> Void) {
+
+        self.delimiter = delimiter
+        self.finishRow = finishRow
+        self.appendChar = appendChar
+        self.finishField = finishField
+    }
+
+    mutating func change(_ char: Character) {
+        if atStart {
+            if char == "\"" {
+                atStart = false
+                parsingQuotes = true
+            } else if char == delimiter {
+                finishField()
+            } else if char.isNewline {
+                finishRow()
+            } else {
+                parsingField = true
+                atStart = false
+                appendChar(char)
+            }
+        } else if parsingField {
+            if innerQuotes {
+                if char == "\"" {
+                    appendChar(char)
+                    innerQuotes = false
+                } else {
+                    fatalError("Can't have non-quote here: \(char)")
+                }
+            } else {
+                if char == "\"" {
+                    innerQuotes = true
+                } else if char == delimiter {
+                    atStart = true
+                    parsingField = false
+                    innerQuotes = false
+                    finishField()
+                } else if char.isNewline {
+                    atStart = true
+                    parsingField = false
+                    innerQuotes = false
+                    finishRow()
+                } else {
+                    appendChar(char)
+                }
+            }
+        } else if parsingQuotes {
+            if innerQuotes {
+                if char == "\"" {
+                    appendChar(char)
+                    innerQuotes = false
+                } else if char == delimiter {
+                    atStart = true
+                    parsingField = false
+                    innerQuotes = false
+                    finishField()
+                } else if char.isNewline {
+                    atStart = true
+                    parsingQuotes = false
+                    innerQuotes = false
+                    finishRow()
+                } else {
+                    fatalError("Can't have non-quote here: \(char)")
+                }
+            } else {
+                if char == "\"" {
+                    innerQuotes = true
+                } else {
+                    appendChar(char)
+                }
+            }
+        } else {
+            fatalError("me_irl")
+        }
+    }
+}

--- a/SwiftCSVTests/CSVTests.swift
+++ b/SwiftCSVTests/CSVTests.swift
@@ -61,8 +61,8 @@ class CSVTests: XCTestCase {
             "name": ["Alice", "Bob", "Charlie"],
             "age": ["18", "19", "20"]
         ]
-        XCTAssertEqual(Array(csv.columns.keys), Array(expected.keys))
-        for (key, value) in csv.columns {
+        XCTAssertEqual(Array(csv.namedColumns.keys), Array(expected.keys))
+        for (key, value) in csv.namedColumns {
             XCTAssertEqual(expected[key] ?? [], value)
         }
     }
@@ -86,7 +86,7 @@ class CSVTests: XCTestCase {
     
     func testIgnoreColumns() {
         csv = CSV(string: "id,name,age\n1,Alice,18\n2,Bob,19\n3,Charlie,20", delimiter: ",", loadColumns: false)
-        XCTAssertEqual(csv.columns.isEmpty, true)
+        XCTAssertEqual(csv.namedColumns.isEmpty, true)
         let expected = [
             ["id": "1", "name": "Alice", "age": "18"],
             ["id": "2", "name": "Bob", "age": "19"],

--- a/SwiftCSVTests/CSVTests.swift
+++ b/SwiftCSVTests/CSVTests.swift
@@ -26,7 +26,7 @@ class CSVTests: XCTestCase {
             ["id": "2", "name": "Bob", "age": "19"],
             ["id": "3", "name": "Charlie", "age": "20"]
         ]
-        for (index, row) in csv.rows.enumerated() {
+        for (index, row) in csv.namedRows.enumerated() {
             XCTAssertEqual(expected[index], row)
         }
     }
@@ -38,7 +38,7 @@ class CSVTests: XCTestCase {
             ["id": "2", "name": "Bob", "age": "19"],
             ["id": "3", "name": "Charlie", "age": ""]
         ]
-        for (index, row) in csv.rows.enumerated() {
+        for (index, row) in csv.namedRows.enumerated() {
             XCTAssertEqual(expected[index], row)
         }
     }
@@ -50,7 +50,7 @@ class CSVTests: XCTestCase {
             ["id": "2", "name": "Bob", "age": "19"],
             ["id": "3", "name": "Charlie", "age": "20"]
         ]
-        for (index, row) in csv.rows.enumerated() {
+        for (index, row) in csv.namedRows.enumerated() {
             XCTAssertEqual(expected[index], row)
         }
     }
@@ -92,7 +92,7 @@ class CSVTests: XCTestCase {
             ["id": "2", "name": "Bob", "age": "19"],
             ["id": "3", "name": "Charlie", "age": "20"]
         ]
-        for (index, row) in csv.rows.enumerated() {
+        for (index, row) in csv.namedRows.enumerated() {
             XCTAssertEqual(expected[index], row)
         }
     }

--- a/SwiftCSVTests/EnumeratedViewTests.swift
+++ b/SwiftCSVTests/EnumeratedViewTests.swift
@@ -1,0 +1,59 @@
+//
+//  EnumeratedViewTests.swift
+//  SwiftCSV
+//
+//  Created by Christian Tietze on 2016-10-25.
+//  Copyright © 2016 Naoto Kaneko. All rights reserved.
+//
+
+import XCTest
+@testable import SwiftCSV
+
+class EnumeratedViewTests: XCTestCase {
+
+    var csv: CSV!
+
+    override func setUp() {
+        super.setUp()
+
+        csv = CSV(string: "id,name,age\n1,Alice,18\n2,Bob,19\n3,Charlie,20", delimiter: ",", loadColumns: true)
+    }
+
+    func testExposesRows() {
+        let expected: [[String]] = [
+            ["1", "Alice", "18"],
+            ["2", "Bob", "19"],
+            ["3", "Charlie", "20"]
+        ]
+        let actual = csv.enumeratedRows
+
+        // Abort if counts don't match to not raise index-out-of-bounds exception
+        guard actual.count == expected.count else {
+            XCTFail("expected actual.count to equal expected.count")
+            return
+        }
+
+        for i in actual.indices {
+            XCTAssertEqual(actual[i], expected[i])
+        }
+    }
+
+    func testExposesColumns() {
+        let actual = csv.enumeratedColumns
+
+        // Abort if counts don't match to not raise index-out-of-bounds exception
+        guard actual.count == 3 else {
+            XCTFail("expected actual.count to equal 3")
+            return
+        }
+
+        XCTAssertEqual(actual[0].header, "id")
+        XCTAssertEqual(actual[0].rows, ["1", "2", "3"])
+
+        XCTAssertEqual(actual[1].header, "name")
+        XCTAssertEqual(actual[1].rows, ["Alice", "Bob", "Charlie"])
+
+        XCTAssertEqual(actual[2].header, "age")
+        XCTAssertEqual(actual[2].rows, ["18", "19", "20"])
+    }
+}

--- a/SwiftCSVTests/PerformanceTest.swift
+++ b/SwiftCSVTests/PerformanceTest.swift
@@ -19,7 +19,7 @@ class PerformanceTest: XCTestCase {
 
     func testParsePerformance() {
         measure {
-            _ = self.csv.rows
+            _ = self.csv.namedRows
         }
     }
 }

--- a/SwiftCSVTests/QuotedTests.swift
+++ b/SwiftCSVTests/QuotedTests.swift
@@ -26,7 +26,7 @@ class QuotedTests: XCTestCase {
     }
     
     func testQuotedContent() {
-        let cols = csv.rows
+        let cols = csv.namedRows
         XCTAssertEqual(cols[0], [
             "id": "5",
             "name, person": "Smith, John",

--- a/SwiftCSVTests/TSVTests.swift
+++ b/SwiftCSVTests/TSVTests.swift
@@ -27,7 +27,7 @@ class TSVTests: XCTestCase {
             ["id": "2", "name": "Bob", "age": "19"],
             ["id": "3", "name": "Charlie", "age": "20"]
         ]
-        for (index, row) in tsv.rows.enumerated() {
+        for (index, row) in tsv.namedRows.enumerated() {
             XCTAssertEqual(expected[index], row)
         }
     }

--- a/SwiftCSVTests/TSVTests.swift
+++ b/SwiftCSVTests/TSVTests.swift
@@ -38,8 +38,8 @@ class TSVTests: XCTestCase {
             "name": ["Alice", "Bob", "Charlie"],
             "age": ["18", "19", "20"]
         ]
-        XCTAssertEqual(Array(tsv.columns.keys), Array(expected.keys))
-        for (key, value) in tsv.columns {
+        XCTAssertEqual(Array(tsv.namedColumns.keys), Array(expected.keys))
+        for (key, value) in tsv.namedColumns {
             XCTAssertEqual(expected[key] ?? [], value)
         }
     }

--- a/SwiftCSVTests/URLTests.swift
+++ b/SwiftCSVTests/URLTests.swift
@@ -23,7 +23,7 @@ class URLTests: XCTestCase {
             ["id": "", "name": "", "age": ""],
             ["id": "", "name": "Tom", "age": ""]
         ]
-        for (index, row) in csv.rows.enumerated() {
+        for (index, row) in csv.namedRows.enumerated() {
             XCTAssertEqual(expected[index], row)
         }
     }
@@ -56,7 +56,7 @@ class URLTests: XCTestCase {
             ],
             [:]
         ]
-        for (index, row) in csv.rows.enumerated() {
+        for (index, row) in csv.namedRows.enumerated() {
             XCTAssertEqual(expected[index], row)
         }
     }


### PR DESCRIPTION
Previously, CSV assumed unique header names. But since a CSV file doesn't necessarily _have_ a header, this caused trouble because of similar dictionary keys.

This PR includes:
- renaming of old properties to `namedRow` and `namedColumn`
  - lazily loaded `NamedView` which holds both row and column information to de-duplicate the "do we have to parse, first?" checks
- addition of `enumeratedRows` and `enumeratedColumns` where the 2D-CSV fields can be iterated over
- refactorings
  - extraction of the parsing state machine into `ParseState` to separate the algorithm from the parts that change

---

What's missing:
- [ ] editing values; at the moment, CSV contents are read-only
